### PR TITLE
Adding setup.sh script for provisioning lab in 1 shoot 1 place

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,21 +185,16 @@ based on CEPH you can provision also ceph boxes.
 
 run:
 
-Create machines without running provisioning scripts:
-```
-vagrant up k8s-master k8s-worker1 k8s-worker2 --no-provision
-```
-
 Run provisioning scripts in two waves
 
 ***k8s-master:***
 ```
-vagrant provision k8s-master
+./setup.sh -m
 ```
 
-***k8s-worker1 & k8s-worker2:***
+***k8s-worker1 & k8s-worker2 & k8s-worker3:***
 ```
-vagrant provision k8s-worker1 k8s-worker2
+./setup.sh -w
 ```
 
 You should see similar output:
@@ -264,7 +259,12 @@ k8s-worker2                    : ok=5    changed=2    unreachable=0    failed=0 
 It can take a while, up to 10 mins. Please be patient.
 
 ## Verification
-From directory where Vagrantfile is located (kubernetes-vagrant) try connect to k8s-master and k8s-worker[1,2] 
+From directory where Vagrantfile is located (kubernetes-vagrant) try connect to k8s-master and k8s-worker[1,2,3] 
+
+### Check if machines are up and running
+```
+./setup -s
+```
 
 ### Test master node:
 

--- a/setup.sh
+++ b/setup.sh
@@ -8,14 +8,33 @@ master_count=2      # master count
 worker_num=1        # worker init number
 worker_count=3      # worker count
 
+usage() {                                     
+   echo
+   echo "Syntax: $0  [-h|a|d|m|w|s]"
+   echo "options:"
+   echo "h          Print help available options"
+   echo "a          Start whole k8s HandsON LAB"
+   echo "d          Destroy k8s HandsON LAB"
+   echo "m          Start k8s HandsON LAB masters only"
+   echo "w          Start k8s HandsON LAB workers only"
+   echo "s          Print k8s HandsON LAB status"
+   echo
+   exit 0
+}
+
+no_option() {                            
+  usage
+  exit 1
+}
+
 function func_prov_master {
-  echo "LAB PROVISIONER START - MASTERS"
+  echo ">>> LAB PROVISIONER START - MASTERS <<<"
   vagrant up k8s-master
   echo "========END PROVISIONER========"
 }
 
 function func_prov_worker {
-  echo "LAB PROVISIONER START - WORKER"
+  echo ">>> LAB PROVISIONER START - WORKER <<<"
   while [ $worker_num -le $worker_count ]
   do
     echo ">>> START PROVISION k8s-worker$worker_num <<<"
@@ -25,6 +44,45 @@ function func_prov_worker {
   echo "========END PROVISIONER========"
 }
 
-# Provision masters and workers
-#func_prov_master()
-func_prov_worker
+function func_destroy {
+  echo ">>> LAB PROVISIONER DESTROY K8S CLUSTER <<<"
+  vagrant destroy -f
+  echo "========END PROVISIONER========"
+}
+
+function func_status {
+  echo ">>> LAB PROVISIONER STATUS K8S CLUSTER <<<"
+  vagrant status
+  echo "========END PROVISIONER========"
+}
+
+while getopts "hadmws" options; do            
+                                                                                        
+  case $options in                          
+    h)
+      usage                                        
+      ;;
+    a)
+      func_prov_master
+      func_prov_worker
+      ;;
+    d)
+      func_destroy
+      ;;
+    m)
+      func_prov_master
+      ;;
+    w) 
+      func_prov_worker
+      ;;
+    s) 
+      func_status
+      ;;
+    *)                                        
+      no_option                           
+      ;;
+  esac
+done
+
+
+


### PR DESCRIPTION
Putting script into right place. Here how to usage:

```
Syntax: ./setup.sh  [-h|a|d|m|w|s]
options:
h          Print help available options
a          Start whole k8s HandsON LAB
d          Destroy k8s HandsON LAB
m          Start k8s HandsON LAB masters only
w          Start k8s HandsON LAB workers only
s          Print k8s HandsON LAB status
```