### PR TITLE
HAProxy webpage statistic added

### DIFF
--- a/ansible/roles/k8s-lb-provision/files/haproxy.cfg
+++ b/ansible/roles/k8s-lb-provision/files/haproxy.cfg
@@ -11,3 +11,11 @@ backend kubernetes-master-nodes
     server k8s-master1 172.16.0.2:6443 check fall 3 rise 2
     server k8s-master2 172.16.0.3:6443 check fall 3 rise 2
     server k8s-master3 172.16.0.4:6443 check fall 3 rise 2
+
+
+listen stats
+    bind :9999
+    mode http
+    stats enable
+    stats hide-version
+    stats uri /stats


### PR DESCRIPTION
Added following configuration:

```
listen stats
    bind :9999
    mode http
    stats enable
    stats hide-version
    stats uri /stats
```

Can be useful during debug process